### PR TITLE
Disabling Py2neo due to deprecation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 logs/
 src/.DS_Store
 */__pycache__/
+env/

--- a/README.md
+++ b/README.md
@@ -1,27 +1,26 @@
-# Auto-complete System
-[![Build Status](https://travis-ci.org/weihesdlegend/Auto-complete-System.svg?branch=master)](https://travis-ci.org/weihesdlegend/Auto-complete-System)
-
-Auto-complete system using Neo4j graph database for storing data and providing fault tolerance. Returns top suggestions to users.
+# Autocomplete System
+Autocomplete system using Neo4j graph database for storing data and providing fault tolerance. Returns top suggestions to users.
 
 ## **Feature Support**
-* Restful search API for auto-completing any phrase in English and returns top suggestions. Auto-correct invalid user inputs.
+* Restful search API for auto-completing any phrase in English and returns top suggestions.
+* Autocorrect invalid user inputs.
 * Delete inappropriate phrases.
 * Build new servers from Neo4j databases.
 * Use advance logging techniques to track usage patterns and generate reports.
 * Serialization and deserialization of servers for data exchange.
 
 ### How to use
-* Python version >= 3.7
-* Install `Python3 venv`
+* Ensure Python version >= 3.8
+* Create a Python virtual environment.
 ```
-macOS/Linux
+# macOS/Linux
 sudo apt-get install python3-venv # If needed
 python3 -m venv env
 source env/bin/activate
 
-Windows
+# Windows
 python -m venv env
 ```
-* Run `pip3 install -r requirements.txt` to install the python3 requirements
+* Run `pip3 install -r requirements.txt` to install the python3 requirements.
 * Run `python service_flask.py` to start REST service.
 * Run `python analytics.py` to generate usage reports.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,3 @@ numpy
 Flask==3.0.2
 # py2neo==4.3.0
 PyYAML
-jinja2==3.1.3
-markupsafe==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ pytest
 redis
 scikit-learn
 numpy
-Flask==1.1.4
-py2neo==4.3.0
-PyYAML==5.4
-jinja2<3.1.0
+Flask==3.0.2
+# py2neo==4.3.0
+PyYAML
+jinja2==3.1.3
 markupsafe==2.0.1

--- a/src/database.py
+++ b/src/database.py
@@ -3,13 +3,14 @@
 """
 
 
-from py2neo import Graph, Relationship
+# from py2neo import Graph, Relationship
 
 
-class Parent(Relationship):
-    pass
+# class Parent(Relationship):
+#     pass
 
 
 class DatabaseHandler:
     def __init__(self, username='neo4j', password='admin', bolt=7687):
-        self.graph = Graph(user=username, password=password, bolt_port=bolt)
+        # self.graph = Graph(user=username, password=password, bolt_port=bolt)
+        return


### PR DESCRIPTION
The Python OGM package Py2neo for neo4j database is deprecating. When users try to install with Python 3.11+ they will encounter error.

This change temporarily disable usages of Py2neo until we find a substitution, most likely be [neomodel](https://neomodel.readthedocs.io/en/latest/index.html).